### PR TITLE
Automatic Docker build upon push for master and release branches

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -14,16 +14,7 @@ if [ $TRAVIS_BRANCH = "master" ]; then
     TAG_VERSION=`git describe --tags`
     echo $TAG_VERSION
     docker build --tag=bluebird .
-    docker tag bluebird turinginst/bluebird:$TAG_VERSION
-    docker push turinginst/bluebird:$TAG_VERSION
-fi
-# If CI on release branch branch then tag with that release number
-if [[ $TRAVIS_BRANCH == release* ]]; then
-    echo $TRAVIS_BRANCH
-    RELEASE_VERSION=`echo $TRAVIS_BRANCH | awk -F/ '{print $NF}'`
-    echo $RELEASE_VERSION
-    docker build --tag=bluebird .
-    for tag in {$RELEASE_VERSION,latest}; do
+    for tag in {$TAG_VERSION,latest}; do
         docker tag bluebird turinginst/bluebird:${tag}
         docker push turinginst/bluebird:${tag}
     done

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -10,7 +10,7 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 # Although there is a warning, the creds are hashed on the travis end first
 cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
-if [ $TRAVIS_BRANCH = "master" ]; then
+if [ "$TRAVIS_BRANCH" = "master" ]; then
     TAG_VERSION=`git describe --tags`
     echo $TAG_VERSION
     docker build --tag=bluebird .

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -11,9 +11,11 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
 if [ $TRAVIS_BRANCH = "master" ]; then
+    RELEASE_VERSION=`git describe --tags`
+    echo $TAG_VERSION
     docker build --tag=bluebird .
-    docker tag bluebird turinginst/bluebird:latest
-    docker push turinginst/bluebird:latest
+    docker tag bluebird turinginst/bluebird:$TAG_VERSION
+    docker push turinginst/bluebird:$TAG_VERSION
 fi
 # If CI on release branch branch then tag with that release number
 if [[ $TRAVIS_BRANCH == release* ]]; then

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ev
+cd $BLUEBIRD_HOME
+# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+# If CI on master branch then tag with latest
+if [ $TRAVIS_BRANCH = "master" ]; then
+    docker build --tag=bluebird .
+    docker tag twitcher turinginst/bluebird:latest
+    docker push turinginst/bluebird:latest
+fi
+# If CI on release branch branch then tag with that release number
+if [ $TRAVIS_OS_NAME = linux ]; then
+    echo $TRAVIS_BRANCH
+    # docker build --tag=bluebird .
+    # docker tag twitcher turinginst/bluebird:1.3.0
+    # docker push turinginst/bluebird:1.3.0
+fi

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 set -ev
 cd $BLUEBIRD_HOME
-# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 # If CI on master branch then tag with latest
 if [ $TRAVIS_BRANCH = "master" ]; then
     docker build --tag=bluebird .
-    docker tag twitcher turinginst/bluebird:latest
-    docker push turinginst/bluebird:latest
+    docker tag bluebird turinginst/bluebird:latest
+    # docker push turinginst/bluebird:latest
 fi
 # If CI on release branch branch then tag with that release number
 if [ $TRAVIS_OS_NAME = linux ]; then
     echo $TRAVIS_BRANCH
-    # docker build --tag=bluebird .
-    # docker tag twitcher turinginst/bluebird:1.3.0
+    RELEASE_VERSION="$TRAVIS_BRANCH" | awk -F/ '{print $NF}'
+    docker build --tag=bluebird .
+    docker tag bluebird turinginst/bluebird:$RELEASE_VERSION
+    docker images --all
     # docker push turinginst/bluebird:1.3.0
 fi

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -ev
-cd $BLUEBIRD_HOME
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt update
-sudo apt -y install docker-ce
-echo '{ "experimental": true }' | sudo tee /etc/docker/daemon.json
-sudo service docker restart
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-# Although there is a warning, the creds are hashed on the travis end first
-cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
 if [ "$TRAVIS_BRANCH" = "master" ]; then
+
+    cd $BLUEBIRD_HOME
+
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt update
+    sudo apt -y install docker-ce
+    echo '{ "experimental": true }' | sudo tee /etc/docker/daemon.json
+    sudo service docker restart
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    # Although there is a warning, the creds are hashed on the travis end first
+    cat /home/travis/.docker/config.json
+
     TAG_VERSION=`git describe --tags`
     echo $TAG_VERSION
     docker build --tag=bluebird .

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -ev
 cd $BLUEBIRD_HOME
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt update
+sudo apt -y install docker-ce
+echo '{ "experimental": true }' | sudo tee /etc/docker/daemon.json
+sudo service docker restart
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
 if [ $TRAVIS_BRANCH = "master" ]; then
     docker build --tag=bluebird .
@@ -11,7 +17,8 @@ fi
 # If CI on release branch branch then tag with that release number
 if [ $TRAVIS_OS_NAME = linux ]; then
     echo $TRAVIS_BRANCH
-    RELEASE_VERSION="$TRAVIS_BRANCH" | awk -F/ '{print $NF}'
+    RELEASE_VERSION=`echo $TRAVIS_BRANCH | awk -F/ '{print $NF}'`
+    echo $RELEASE_VERSION
     docker build --tag=bluebird .
     docker tag bluebird turinginst/bluebird:$RELEASE_VERSION
     docker images --all

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -ev
 # If CI on master branch then tag with latest
-if [ "$TRAVIS_BRANCH" = "master" ]; then
+echo $TRAVIS_BRANCH
+echo $TRAVIS_PULL_REQUEST
+
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] ; then
 
     cd $BLUEBIRD_HOME
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -7,20 +7,20 @@ sudo apt -y install docker-ce
 echo '{ "experimental": true }' | sudo tee /etc/docker/daemon.json
 sudo service docker restart
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+# Although there is a warning, the creds are hashed on the travis end first
 cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
 if [ $TRAVIS_BRANCH = "master" ]; then
     docker build --tag=bluebird .
     docker tag bluebird turinginst/bluebird:latest
-    # docker push turinginst/bluebird:latest
+    docker push turinginst/bluebird:latest
 fi
 # If CI on release branch branch then tag with that release number
-if [ $TRAVIS_OS_NAME = linux ]; then
+if [[ $TRAVIS_BRANCH == release* ]]; then
     echo $TRAVIS_BRANCH
     RELEASE_VERSION=`echo $TRAVIS_BRANCH | awk -F/ '{print $NF}'`
     echo $RELEASE_VERSION
     docker build --tag=bluebird .
     docker tag bluebird turinginst/bluebird:$RELEASE_VERSION
-    docker images --all
-    # docker push turinginst/bluebird:1.3.0
+    docker push turinginst/bluebird:$RELEASE_VERSION
 fi

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -11,7 +11,7 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 cat /home/travis/.docker/config.json
 # If CI on master branch then tag with latest
 if [ $TRAVIS_BRANCH = "master" ]; then
-    RELEASE_VERSION=`git describe --tags`
+    TAG_VERSION=`git describe --tags`
     echo $TAG_VERSION
     docker build --tag=bluebird .
     docker tag bluebird turinginst/bluebird:$TAG_VERSION
@@ -23,6 +23,8 @@ if [[ $TRAVIS_BRANCH == release* ]]; then
     RELEASE_VERSION=`echo $TRAVIS_BRANCH | awk -F/ '{print $NF}'`
     echo $RELEASE_VERSION
     docker build --tag=bluebird .
-    docker tag bluebird turinginst/bluebird:$RELEASE_VERSION
-    docker push turinginst/bluebird:$RELEASE_VERSION
+    for tag in {$RELEASE_VERSION,latest}; do
+        docker tag bluebird turinginst/bluebird:${tag}
+        docker push turinginst/bluebird:${tag}
+    done
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
   - master
   - /^release\/.*$/
   - /^hotfix\/.*$/
-  - /^issue\/.*$/
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
-
 branches:
   only:
   - master
   - /^release\/.*$/
   - /^hotfix\/.*$/
+  - /^issue\/.*$/
 
 language: python
 python:
   - "3.6"
 
-services:
-  - docker
+before_install:
+  - "git pull --all"
+  - "echo $PWD"
+  - "export BLUEBIRD_HOME=$PWD"
 
 install:
   - pip install -r requirements.txt
@@ -19,3 +21,6 @@ install:
 script:
   - pytest -rs --ignore=./tests/integration ./tests
   - pytest -rs  ./tests/integration
+
+after_success:
+  - "bash $BLUEBIRD_HOME/.travis-build.sh"


### PR DESCRIPTION
Fixes #72 

This PR automatically builds a new docker image upon successful completion of tests on the `master` and `release` branches. Depending which branch is it on, either the latest or release number will be used as the docker image tag.

This has almost been completely [tested](https://travis-ci.com/alan-turing-institute/bluebird/jobs/230341634) , except for the situation of pushing the new build. 

For this reason an early PR has been created such that this can be inspected and perhaps given the go ahead to test on a dummy release branch.

Note, the `issue/72/CI-image-build` branch was branched off `release/1.3.0` but has now been rebased on top of `master` following the merge of `release/1.3.0` into `master`