### PR TITLE
[HOTFIX] Updating pytest dependency to fix error

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 
 # In addition to requirements.txt, the following are required for development and testing
 
-pytest == 4.1.*
+pytest == 5.2.0
 pytest-docker-compose == 1.0.*
 pylint == 2.2.*
 pylint-exit == 1.0.*


### PR DESCRIPTION
It was discovered in builds from https://github.com/alan-turing-institute/dodo/pull/79
and https://github.com/alan-turing-institute/dodo/pull/78 a failure has occurred on Travis

Command:
    `$ pytest -rs --ignore=./tests/integration ./tests`

Error:
    `TypeError: attrib() got an unexpected keyword argument 'convert'`

It appears that pytest seems to have the package attrs as a dependency.

REF:
    https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert

    modified:   requirements.txt