### PR TITLE
Issue/190/bluebird docker

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@
 BS_PATH="./bluesky"
 
 # Minimum version of BlueSky required to run
-BS_MIN_VERSION=1.4.0-dev
+BS_MIN_VERSION=1.4.0
 
 # MachColl vars
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN if [ ! -z $NATS_PYPI_INDEX ]; then \
 COPY ./bluesky/bluesky ./bluesky/bluesky
 COPY .env run.py VERSION ./
 COPY ./bluebird ./bluebird
+COPY wait-for-it.sh ./wait-for-it.sh
+RUN chmod +x ./wait-for-it.sh
+
 RUN find . -type d -name '__pycache__' -prune -exec rm -r {} \;
 
 ENV FLASK_ENV=development

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 # BlueBird
 
-BlueBird is a web API for air traffic simulators. The only open-source simulator currently supported is [BlueSky](https://github.com/alan-turing-institute/bluesky).
+BlueBird provides a [Flask](https://github.com/pallets/flask)-based API to air traffic control simulators. In addition to basic communication, it also includes features such as performance metrics (via [Aviary](https://github.com/alan-turing-institute/aviary)), and logging of scenario data. The main purpose of BlueBird is to provide a common interface between different air traffic simulators for the overall goal of developing AI agents.
+
+The currently supported open-source simulator is [BlueSky](https://github.com/alan-turing-institute/bluesky).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # BlueBird
 
-BlueBird provides a [Flask](https://github.com/pallets/flask)-based API to air traffic control simulators. In addition to basic communication, it also includes features such as performance metrics (via [Aviary](https://github.com/alan-turing-institute/aviary)), and logging of scenario data. The main purpose of BlueBird is to provide a common interface between different air traffic simulators for the overall goal of developing AI agents.
+BlueBird provides a common [Flask](https://github.com/pallets/flask)-based API to multiple air traffic simulators. In addition to basic communication, it also includes features such as state caching, performance metrics (via [Aviary](https://github.com/alan-turing-institute/aviary)), and logging of scenario data. The main purpose of BlueBird is to provide a common interface to ease the research & development of AI for air traffic control.
 
 The currently supported open-source simulator is [BlueSky](https://github.com/alan-turing-institute/bluesky).
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Python Version](https://img.shields.io/badge/python-3.7-blue)
 ![License](https://img.shields.io/github/license/alan-turing-institute/bluebird)
 ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 # BlueBird
 

--- a/bluebird/sim_client/machcoll/sim_client.py
+++ b/bluebird/sim_client/machcoll/sim_client.py
@@ -72,6 +72,9 @@ class SimClient(AbstractSimClient):
         )
 
     def connect(self, timeout: int = 1) -> None:
+        self._logger.info(
+            f"Creating MCClientMetrics. MQ_URL is: {os.environ['MQ_URL']}"
+        )
         self._mc_client = MCClientMetrics(host=Settings.SIM_HOST, port=Settings.MC_PORT)
         self._mc_bg_client = MCClientMetrics(
             host=Settings.SIM_HOST, port=Settings.MC_PORT

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -1,5 +1,5 @@
 
+# NOTE(rkm 2020-03-27) "pip install nats.mc-client" does not currently include pika
 pika
-requests
 
 nats.mc-client==2020.3.9.dev5575

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -1,2 +1,5 @@
 
-nats.mc_client==2020.2.27.dev5202
+pika
+requests
+
+nats.mc_client==2020.3.3.dev5369

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -2,4 +2,4 @@
 pika
 requests
 
-nats.mc_client==2020.3.3.dev5369
+nats.mc-client==2020.3.9.dev5575

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -1,2 +1,2 @@
 
-nats.mc-client
+nats.mc_client==2020.2.27.dev5202

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ flask-restful == 0.3.*
 flask-cors == 3.0.*
 semver == 2.8.*
 python-dotenv == 0.10.*
-pyproj == 2.2.*
 jsonschema
 
 # Required by BlueSky. Versions unknown

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,6 @@ python-dotenv == 0.10.*
 pyproj == 2.2.*
 jsonschema
 
-pika
-requests
-
 # Required by BlueSky. Versions unknown
 matplotlib
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ python-dotenv == 0.10.*
 pyproj == 2.2.*
 jsonschema
 
+pika
+requests
+
 # Required by BlueSky. Versions unknown
 matplotlib
 numpy

--- a/run.py
+++ b/run.py
@@ -13,7 +13,6 @@ from bluebird.settings import Settings
 from bluebird.utils.properties import SimType
 
 _ARG_BOOL_ACTION = "store_true"
-_DEFAULT_MQ_URL = "amqp://guest:guest@localhost:5672/%2F"
 
 
 def _parse_args() -> Dict[str, Any]:
@@ -57,8 +56,6 @@ def _parse_args() -> Dict[str, Any]:
     #     Settings.SIM_MODE = args.sim_mode
 
     if args.sim_type:
-        if args.sim_type == SimType.MachColl and os.environ.get("MQ_URL", None) is None:
-            os.environ["MQ_URL"] = _DEFAULT_MQ_URL
         Settings.SIM_TYPE = args.sim_type
 
     return vars(args)

--- a/tests/integration/bluesky/docker-compose.yml
+++ b/tests/integration/bluesky/docker-compose.yml
@@ -1,4 +1,7 @@
 ---
+
+# NOTE(rkm 2020-03-27) This file is only intended for the integration tests and should not be modified
+
 version: "3.7"
 
 services:

--- a/tests/integration/common/episode_reload_test.py
+++ b/tests/integration/common/episode_reload_test.py
@@ -3,15 +3,8 @@ Tests for the episode reloading
 """
 import pytest
 import requests
-from pyproj import Geod
 
 import tests.integration
-
-
-_WGS84 = Geod(ellps="WGS84")
-_ONE_NM = 1852  # Meters
-_ONE_FT = 0.3048  # Meters
-
 
 def test_episode_reload_basic():
     """
@@ -20,84 +13,3 @@ def test_episode_reload_basic():
     """
 
     pytest.xfail()
-
-    api_base = tests.integration.API_BASE
-
-    test_acid = "KL204"
-
-    resp = requests.post(f"{api_base}/simmode", json={"mode": "agent"})
-    assert resp.status_code == 200, "Expected the mode to be set"
-
-    resp = requests.post(f"{api_base}/seed", json={"value": 123123})
-    assert resp.status_code == 200, "Expected that the seed was set"
-
-    resp = requests.post(f"{api_base}/ic", json={"filename": "TEST.scn"})
-    assert resp.status_code == 200, "Expected that the scenario was loaded"
-
-    resp = requests.post(f"{api_base}/dtmult", json={"multiplier": 20})
-    assert resp.status_code == 200, "Expected DTMULT to be set"
-
-    # Do an initial step
-    resp = requests.post(f"{api_base}/step")
-    assert resp.status_code == 200, "Expected the simulation was stepped"
-
-    # Change altitude and heading
-    resp = requests.post(f"{api_base}/alt", json={"acid": test_acid, "alt": "FL100"})
-    assert resp.status_code == 200, "Expected the aircraft altitude to be changed"
-
-    resp = requests.post(f"{api_base}/hdg", json={"acid": test_acid, "hdg": "180"})
-    assert resp.status_code == 200, "Expected the aircraft heading to be changed"
-
-    for _ in range(3):
-        resp = requests.post(f"{api_base}/step")
-        assert resp.status_code == 200, "Expected the simulation was stepped"
-
-    # Get the position here
-    resp = requests.get(f"{api_base}/pos?acid={test_acid}")
-    assert resp.status_code == 200, "Expected to get the aircraft position"
-
-    initial_t = resp.json()["sim_t"]
-    initial_pos = resp.json()[test_acid]
-
-    # Step some more
-    for _ in range(3):
-        resp = requests.post(f"{api_base}/step")
-        assert resp.status_code == 200, "Expected the simulation was stepped"
-
-    # Now get the episode log and reload to the middle of the log
-
-    resp = requests.get(f"{api_base}/eplog")
-    assert resp.status_code == 200, "Expected to receive the episode log"
-
-    episode_file = resp.json()["cur_ep_file"]
-    data = {"filename": episode_file, "time": initial_t}
-    resp = requests.post(f"{api_base}/loadlog", json=data)
-    assert resp.status_code == 200, "Expected the simulation was reloaded"
-
-    # Now get the reloaded position and compare with the initial
-
-    resp = requests.get(f"{api_base}/pos?acid={test_acid}")
-    assert resp.status_code == 200, "Expected to get the aircraft position"
-
-    reloaded_t = resp.json()["sim_t"]
-    reloaded_pos = resp.json()[test_acid]
-
-    assert (
-        abs(reloaded_t - initial_t) <= 1
-    ), "Expected the reloaded time to be at the target"
-
-    _, _, horizontal_sep_m = _WGS84.inv(
-        initial_pos["lon"], initial_pos["lat"], reloaded_pos["lon"], reloaded_pos["lat"]
-    )
-
-    # TODO Check the deltas are reasonable...
-    assert round(horizontal_sep_m / _ONE_NM) <= 5, "Expected positions to roughly match"
-    assert (
-        abs(reloaded_pos["alt"] - initial_pos["alt"]) <= 100 / _ONE_FT
-    ), "Expected altitudes to roughly match"
-    assert (
-        abs(reloaded_pos["gs"] - initial_pos["gs"]) <= 50
-    ), "Expected ground speeds to roughly match"
-    assert (
-        abs(reloaded_pos["vs"] - initial_pos["vs"]) <= 50
-    ), "Expected vertical speeds to roughly match"

--- a/tests/integration/machcoll/docker-compose.yml
+++ b/tests/integration/machcoll/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 15672:15672
   metrics:
     container_name: machcoll_metrics_integration
-    image: nats-metrics-img
+    image: nats-metrics-img:master-9a39559
     depends_on:
       - rabbitmq
     ports:
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
   machcoll:
     container_name: machcoll_integration
-    image: machcoll-img
+    image: machcoll-img:dev-1bea126
     depends_on:
       - metrics
     ports:
@@ -32,20 +32,20 @@ services:
     restart: unless-stopped
   # NOTE(rkm 2020-01-31) For debugging, you can uncomment this section and use this as a
   # standard docker-compose file
-  bluebird:
-    container_name: bluebird_integration
-    build:
-      args:
-        - NATS_PYPI_INDEX=$NATS_PYPI_INDEX
-      context: ../../../
-    depends_on:
-      - machcoll
-    volumes:
-      - /usr/src/app/logs/ # Prevents any local logs being copied to the container
-    ports:
-      - 5001:5001
-    environment:
-      - PYTHONUNBUFFERED=1
-      - MQ_URL="amqp://guest:guest@localhost:5672/%2F"
-    command: python ./run.py --sim-type=machcoll
-    restart: unless-stopped
+  # bluebird:
+  #   container_name: bluebird_integration
+  #   build:
+  #     args:
+  #       - NATS_PYPI_INDEX=$NATS_PYPI_INDEX
+  #     context: ../../../
+  #   depends_on:
+  #     - machcoll
+  #   volumes:
+  #     - /usr/src/app/logs/ # Prevents any local logs being copied to the container
+  #   ports:
+  #     - 5001:5001
+  #   environment:
+  #     - PYTHONUNBUFFERED=1
+  #     - MQ_URL="amqp://guest:guest@localhost:5672/%2F"
+  #   command: sh -c "./wait-for-it.sh --timeout=0 machcoll:5321 && python ./run.py --sim-type=machcoll"
+  #   restart: unless-stopped

--- a/tests/integration/machcoll/docker-compose.yml
+++ b/tests/integration/machcoll/docker-compose.yml
@@ -1,4 +1,7 @@
 ---
+
+# NOTE(rkm 2020-03-27) This file is only intended for the integration tests and should not be modified
+
 version: "3.7"
 
 services:
@@ -30,8 +33,6 @@ services:
       - MC_SCENARIO_FILENAME
       - MC_AIRSPACE_FILENAME
     restart: unless-stopped
-  # NOTE(rkm 2020-01-31) For debugging, you can uncomment this section and use this as a
-  # standard docker-compose file
   bluebird:
     container_name: bluebird_integration
     build:

--- a/tests/integration/machcoll/docker-compose.yml
+++ b/tests/integration/machcoll/docker-compose.yml
@@ -46,6 +46,5 @@ services:
       - 5001:5001
     environment:
       - PYTHONUNBUFFERED=1
-      - MQ_URL="amqp://guest:guest@localhost:5672/%2F"
-    command: sh -c "./wait-for-it.sh --timeout=0 machcoll:5321 && python ./run.py --sim-type=machcoll"
+    command: sh -c "./wait-for-it.sh --timeout=0 machcoll:5321 && python ./run.py --sim-type=machcoll --sim-host=machcoll"
     restart: unless-stopped

--- a/tests/integration/machcoll/docker-compose.yml
+++ b/tests/integration/machcoll/docker-compose.yml
@@ -32,20 +32,20 @@ services:
     restart: unless-stopped
   # NOTE(rkm 2020-01-31) For debugging, you can uncomment this section and use this as a
   # standard docker-compose file
-  # bluebird:
-  #   container_name: bluebird_integration
-  #   build:
-  #     args:
-  #       - NATS_PYPI_INDEX=$NATS_PYPI_INDEX
-  #     context: ../../../
-  #   depends_on:
-  #     - machcoll
-  #   volumes:
-  #     - /usr/src/app/logs/ # Prevents any local logs being copied to the container
-  #   ports:
-  #     - 5001:5001
-  #   environment:
-  #     - PYTHONUNBUFFERED=1
-  #     - MQ_URL="amqp://guest:guest@localhost:5672/%2F"
-  #   command: sh -c "./wait-for-it.sh --timeout=0 machcoll:5321 && python ./run.py --sim-type=machcoll"
-  #   restart: unless-stopped
+  bluebird:
+    container_name: bluebird_integration
+    build:
+      args:
+        - NATS_PYPI_INDEX=$NATS_PYPI_INDEX
+      context: ../../../
+    depends_on:
+      - machcoll
+    volumes:
+      - /usr/src/app/logs/ # Prevents any local logs being copied to the container
+    ports:
+      - 5001:5001
+    environment:
+      - PYTHONUNBUFFERED=1
+      - MQ_URL="amqp://guest:guest@localhost:5672/%2F"
+    command: sh -c "./wait-for-it.sh --timeout=0 machcoll:5321 && python ./run.py --sim-type=machcoll"
+    restart: unless-stopped

--- a/tests/integration/machcoll/docker-compose.yml
+++ b/tests/integration/machcoll/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 15672:15672
   metrics:
     container_name: machcoll_metrics_integration
-    image: nats-metrics-img:master-9a39559
+    image: nats-metrics-img
     depends_on:
       - rabbitmq
     ports:
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
   machcoll:
     container_name: machcoll_integration
-    image: machcoll-img:dev-1bea126
+    image: machcoll-img
     depends_on:
       - metrics
     ports:

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
Fixes https://github.com/alan-turing-institute/nats/issues/190

    It turns out that the main blocker nats#190 was that `MQ_URL` was being overridden inside
    `bluebird/run.py:16` and `bluebird/run.py:61`

    This prevents the Flask server from coming up when running in a container.

    Running `bluebird` locally should then be run in a way something like:

    export MQ_URL="amqp://guest:guest@localhost:5672/%2F" && python run.py --sim-type=machcoll --sim-host=localhost

    Whereas for running inside the docker container, this `$MQ_URL` should be `unset` _before_ firing
    up, as the default (`MQ_URL=amqp://guest:guest@rabbitmq:5672/%2F`) is required for the connection to
    take place.

    REF:
    https://github.com/alan-turing-institute/nats/issues/190

            modified:   tests/integration/machcoll/docker-compose.yml

            modified:   run.py
